### PR TITLE
Support Remove reliance on DIRECTORY_SEPARATOR. Code fails on Windows, s...

### DIFF
--- a/lib/SiTech/Loader.php
+++ b/lib/SiTech/Loader.php
@@ -113,8 +113,8 @@ class SiTech_Loader
 		$name = strtolower($name);
 		$class = null;
 
-		if (strstr($name, DIRECTORY_SEPARATOR) !== false) {
-			$parts = explode(DIRECTORY_SEPARATOR, $name);
+		if (strpos($name, '/') !== false || strpos($name, '\\') !== false) {
+			$parts = preg_split('|[\\\/]|', $name);
 			$parts = array_map('ucfirst', $parts);
 			$class = implode('_', $parts).'Controller';
 		} else {


### PR DESCRIPTION
I didn't backport master Loader to release 1.2. Master requires '/' and this pull request allows for either '/' or '\'. I am sure that '\' is an edge case. Except that there might be Windows users on IIS that might use the stable library and this would allow them to work within their paradigm.

Truthfully, might just as well backport master.
