### PR TITLE
*  escaping field names for _update() & _insert() methods

### DIFF
--- a/lib/SiTech/Model/Abstract.php
+++ b/lib/SiTech/Model/Abstract.php
@@ -470,7 +470,7 @@ abstract class SiTech_Model_Abstract
 		foreach ($tmp_fields as $f => $v) {
 			// allow for manually setting primary keys!!! -- rmp
 			if (in_array($f, $pk) && empty( $v )) continue;
-			$fields[] = $f;
+			$fields[] = '`' . $f . '`';
 			// TODO what happens if $v is an array (i.e. has many)?
 			$values[$f] = ($v instanceof SiTech_Model_Abstract)? $v->{$v::pk()} : $v;
 		}
@@ -510,7 +510,7 @@ abstract class SiTech_Model_Abstract
 #		foreach ($this->_modified as $f => $v) {
 		foreach ($tmp_fields as $f => $v) {
 			if (in_array( $f, $pk)) continue; // We don't update the value of the pk
-			$fields[] = $f.' = :' . $f;
+			$fields[] = '`' . $f.'` = :' . $f;
 			$values[$f] = ($v instanceof SiTech_Model_Abstract)? $v->{$v::pk()} : $v;
 		}
 


### PR DESCRIPTION
Might be better to have some way to customize how to escape field names based on which database is being used.
