### PR TITLE
Release 1.2

### DIFF
--- a/lib/SiTech/Model/Abstract.php
+++ b/lib/SiTech/Model/Abstract.php
@@ -475,7 +475,7 @@ abstract class SiTech_Model_Abstract
 			$values[$f] = ($v instanceof SiTech_Model_Abstract)? $v->{$v::pk()} : $v;
 		}
 
-		$sql .= '('.implode(',', $fields).') VALUES(:'.implode(',:', $fields).')';
+		$sql .= '(`'.implode('`,`', $fields).'`) VALUES(:'.implode(',:', $fields).')';
 		$stmnt = $this->_db->prepare($sql);
 		if ($stmnt->execute($values)) {
 			// Assign the PK once the row is inserted
@@ -510,7 +510,7 @@ abstract class SiTech_Model_Abstract
 #		foreach ($this->_modified as $f => $v) {
 		foreach ($tmp_fields as $f => $v) {
 			if (in_array( $f, $pk)) continue; // We don't update the value of the pk
-			$fields[] = $f.' = :' . $f;
+			$fields[] = '`'.$f.'` = :' . $f;
 			$values[$f] = ($v instanceof SiTech_Model_Abstract)? $v->{$v::pk()} : $v;
 		}
 

--- a/lib/SiTech/Model/Abstract.php
+++ b/lib/SiTech/Model/Abstract.php
@@ -510,7 +510,7 @@ abstract class SiTech_Model_Abstract
 #		foreach ($this->_modified as $f => $v) {
 		foreach ($tmp_fields as $f => $v) {
 			if (in_array( $f, $pk)) continue; // We don't update the value of the pk
-			$fields[] = '`' . $f.'` = :' . $f;
+			$fields[] = '`' . $f . '` = :' . $f;
 			$values[$f] = ($v instanceof SiTech_Model_Abstract)? $v->{$v::pk()} : $v;
 		}
 


### PR DESCRIPTION
Fixes bug in the current implementation. Line 473 will error out, since it effects the prepared statement part of the SQL statement with the '`' character.

The correction fixes the problem and properly escapes the SQL.

The other part is simply spaces.
